### PR TITLE
Expose Http Request Headers

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -6,15 +6,15 @@ import gzip from './archive/gzip';
 import zip from './archive/zip';
 import tar from './archive/tar';
 
-import { Headers } from './index';
+import { HttpOptions } from './index';
 
 type FileEntry = {
   data: Buffer;
   path: string;
 };
 
-async function downloadAndUnpack(url: URL, filepath: string, binary: string, headers: Headers = {}) {
-  const payload = await download(url, headers);
+async function downloadAndUnpack(url: URL, filepath: string, binary: string, options: HttpOptions = {}) {
+  const payload = await download(url, options);
   const files = await extract(payload);
 
   const found = files.filter(x => x.path == filepath);
@@ -24,10 +24,10 @@ async function downloadAndUnpack(url: URL, filepath: string, binary: string, hea
   return await save(found[0], binary);
 }
 
-async function download(url: URL, headers: Headers) {
+async function download(url: URL, options: HttpOptions) {
   return await axios.get(url.toString(), {
     responseType: 'arraybuffer',
-    headers: headers,
+    headers: options.headers,
   }).then((res) => {
     return res.data;
   }).catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,10 @@ export type Headers = {
   [key: string]: string;
 }
 
+export type HttpOptions = {
+  headers?: Headers;
+}
+
 type OSArchMapping = {
   path: URL;
   os: OS;
@@ -19,7 +23,7 @@ type OSArchMapping = {
 }
 
 export class BinWrapper {
-  #headers: Headers = {};
+  #httpOptions: HttpOptions = {};
   #sources: OSArchMapping[] = [];
   #path: string = path.join(__dirname, 'bin');
   #name = 'bin';
@@ -39,8 +43,8 @@ export class BinWrapper {
     return this;
   }
 
-  httpHeaders(headers: Headers): BinWrapper {
-    this.#headers = headers;
+  httpOptions(options: HttpOptions): BinWrapper {
+    this.#httpOptions = options;
     return this;
   }
 
@@ -49,7 +53,7 @@ export class BinWrapper {
       return;
     }
     const downloadUrl = this.#findMatchingPlatform();
-    await downloadAndUnpack(downloadUrl.path, this.#name, path.join(this.#path, this.#name), this.#headers);
+    await downloadAndUnpack(downloadUrl.path, this.#name, path.join(this.#path, this.#name), this.#httpOptions);
   }
 
   async run(args: string[]): Promise<number> {

--- a/test/download.spec.ts
+++ b/test/download.spec.ts
@@ -149,8 +149,10 @@ test('Headers are carried over', async () => {
     });
   });
   await downloadAndUnpack(new URL('http:/dummy-host/archive.tar'), 'dummy.txt', 'dummy.txt', {
-    'user-agent': 'dummy-UA',
-    auth: 'Bearer XXX'
+    headers: {
+      'user-agent': 'dummy-UA',
+      auth: 'Bearer XXX',
+    },
   });
   expect(usedFilename).toBe('dummy.txt');
   expect(usedBody).toEqual(Buffer.from('dummy-content'));

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -105,10 +105,10 @@ describe('BinWrapper', () => {
     mockedFsPromises.stat.mockImplementation(fsStatFailure);
     mockedDownload.downloadAndUnpack.mockResolvedValue();
 
-    bw.httpHeaders({ auth: 'Bearer XXX' });
+    bw.httpOptions({ headers: { auth: 'Bearer XXX' } });
     await bw.install()
     expect(mockedDownload.downloadAndUnpack).toHaveBeenCalledTimes(1);
-    expect(mockedDownload.downloadAndUnpack).toHaveBeenCalledWith(new URL('http://dummy-host/dummy.tar'), 'dummy', '/tmp/binary/dummy', {'auth': "Bearer XXX"});
+    expect(mockedDownload.downloadAndUnpack).toHaveBeenCalledWith(new URL('http://dummy-host/dummy.tar'), 'dummy', '/tmp/binary/dummy', { headers: { 'auth': "Bearer XXX" } });
   });
 
   test('bin-wrapper: do not download if installed', async () => {


### PR DESCRIPTION
Exposes headers of the underlying HTTP Request.
It can be used to carry authentication for example.